### PR TITLE
ApiKeyクラスを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+app/src/main/java/com/example/recipegenerator/network/ApiKey.kt


### PR DESCRIPTION
ApiKeyクラスを作成して.gitignoreに追加しました。
これでAPIキーが晒されることは無くなります。
ないとは思いますが、ApiKey.ktの位置を変えないように気をつけてください(別フォルダに移動させる等)